### PR TITLE
feat: add supported keys for keyDown step.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,21 @@ const stringifiedContent = await cypressStringifyChromeRecording(
 return stringifiedContent;
 ```
 
+## Supported Chrome Recorder Step Types
+
+Below are the step types that are currently supported:
+
+| Type        | Description                                   |
+| ----------- | --------------------------------------------- |
+| click       | becomes **cy.click(element)**                 |
+| change      | becomes **cy.get(element).type("text")**      |
+| keyDown     | becomes **cy.type("{key}")**                  |
+| navigate    | becomes **cy.visit("url")**                   |
+| setViewport | becomes **cy.viewport(width, height)**        |
+| scroll      | becomes **cy.scrollTo(${step.x}, ${step.y})** |
+
+If a step type is not supported (ie. `keyUp`) then a warning message will be displayed in the CLI.
+
 ## License
 
 [![license](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/cypress-io/cypress-chrome-recorder/blob/master/LICENSE)

--- a/README.md
+++ b/README.md
@@ -78,11 +78,12 @@ Below are the step types that are currently supported:
 | click       | becomes **cy.click(element)**                 |
 | change      | becomes **cy.get(element).type("text")**      |
 | keyDown     | becomes **cy.type("{key}")**                  |
+| keyUp       | _not exported at this time_                   |
 | navigate    | becomes **cy.visit("url")**                   |
 | setViewport | becomes **cy.viewport(width, height)**        |
 | scroll      | becomes **cy.scrollTo(${step.x}, ${step.y})** |
 
-If a step type is not supported (ie. `keyUp`) then a warning message will be displayed in the CLI.
+If a step type is not listed above, then a warning message should be displayed in the CLI.
 
 ## License
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -21,4 +21,51 @@ export const recorderChangeTypes: RecorderChangeTypes[] = [
   'email',
 ];
 
+export type SupportedRecorderKeysKeys =
+  | 'backspace'
+  | 'enter'
+  | 'arrowUp'
+  | 'arrowDown'
+  | 'arrowLeft'
+  | 'arrowRight'
+  | 'escape'
+  | 'pageUp'
+  | 'pageDown'
+  | 'end'
+  | 'home'
+  | 'insert';
+
+type SupportedRecorderKeysValues =
+  | 'backspace'
+  | 'enter'
+  | 'upArrow'
+  | 'downArrow'
+  | 'leftArrow'
+  | 'rightArrow'
+  | 'esc'
+  | 'pageUp'
+  | 'pageDown'
+  | 'end'
+  | 'home'
+  | 'insert';
+
+type SupportedRecorderKeys = {
+  [key in SupportedRecorderKeysKeys]: SupportedRecorderKeysValues;
+};
+
+export const supportedRecorderKeys: SupportedRecorderKeys = {
+  backspace: 'backspace',
+  enter: 'enter',
+  arrowUp: 'upArrow',
+  arrowDown: 'downArrow',
+  arrowLeft: 'leftArrow',
+  arrowRight: 'rightArrow',
+  escape: 'esc',
+  pageUp: 'pageUp',
+  pageDown: 'pageDown',
+  end: 'end',
+  home: 'home',
+  insert: 'insert',
+};
+
 export const defaultOutputFolder = 'cypress/integration';


### PR DESCRIPTION
This PR adds support for the `keyDown` step type. It enables support for special sequences found in both DevTools Recorder and the [cy.type](https://docs.cypress.io/api/commands/type#Arguments) documentation.

Fixes #14.