### PR TITLE
feat(dblclick): add support for dblclick.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This repo provides tools to export Cypress Tests from Google Chrome DevTools' Re
 
 In order to export JSON files from Chrome DevTools Recorder you will need to be on Chrome 101 or newer.
 
+`dblClick` requires Chrome 103 or newer.
+
 ## Installation
 
 ```sh
@@ -75,8 +77,9 @@ Below are the step types that are currently supported:
 
 | Type        | Description                                   |
 | ----------- | --------------------------------------------- |
-| click       | becomes **cy.click(element)**                 |
-| change      | becomes **cy.get(element).type("text")**      |
+| click       | becomes **cy.get("_element_").click();**      |
+| doubleClick | becomes **cy.get("_element_").dblclick();**   |
+| change      | becomes **cy.get("_element_").type("text")**  |
 | keyDown     | becomes **cy.type("{key}")**                  |
 | keyUp       | _not exported at this time_                   |
 | navigate    | becomes **cy.visit("url")**                   |

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/cypress-io/cypress-chrome-recorder#readme",
   "dependencies": {
-    "@puppeteer/replay": "^0.1.1",
+    "@puppeteer/replay": "^0.1.2",
     "chalk": "^4.1.2",
     "execa": "^6.1.0",
     "globby": "^13.1.1",

--- a/src/CypressStringifyExtension.ts
+++ b/src/CypressStringifyExtension.ts
@@ -73,7 +73,7 @@ export class CypressStringifyExtension extends StringifyExtension {
 
   #appendClickStep(
     out: LineWriter,
-    step: Schema.ClickStep | Schema.DoubleClickStep,
+    step: Schema.ClickStep,
     flow: Schema.UserFlow
   ): void {
     const cySelector = handleSelectors(step.selectors, flow);

--- a/src/CypressStringifyExtension.ts
+++ b/src/CypressStringifyExtension.ts
@@ -39,7 +39,7 @@ export class CypressStringifyExtension extends StringifyExtension {
       case 'click':
         return this.#appendClickStep(out, step, flow);
       case 'doubleClick':
-        return this.#appendClickStep(out, step, flow);
+        return this.#appendDoubleClickStep(out, step, flow);
       case 'change':
         return this.#appendChangeStep(out, step, flow);
       case 'setViewport':
@@ -79,9 +79,25 @@ export class CypressStringifyExtension extends StringifyExtension {
     const cySelector = handleSelectors(step.selectors, flow);
 
     if (cySelector) {
-      step.type === 'doubleClick'
-        ? out.appendLine(`${cySelector}.dblclick();`)
-        : out.appendLine(`${cySelector}.click();`);
+      out.appendLine(`${cySelector}.click();`);
+    } else {
+      console.log(
+        `Warning: The click on ${step.selectors[0]} was not able to be exported to Cypress. Please adjust your selectors and try again.`
+      );
+    }
+
+    out.appendLine('');
+  }
+
+  #appendDoubleClickStep(
+    out: LineWriter,
+    step: Schema.DoubleClickStep,
+    flow: Schema.UserFlow
+  ): void {
+    const cySelector = handleSelectors(step.selectors, flow);
+
+    if (cySelector) {
+      out.appendLine(`${cySelector}.dblclick();`);
     } else {
       console.log(
         `Warning: The click on ${step.selectors[0]} was not able to be exported to Cypress. Please adjust your selectors and try again.`

--- a/src/CypressStringifyExtension.ts
+++ b/src/CypressStringifyExtension.ts
@@ -38,6 +38,8 @@ export class CypressStringifyExtension extends StringifyExtension {
     switch (step.type) {
       case 'click':
         return this.#appendClickStep(out, step, flow);
+      case 'doubleClick':
+        return this.#appendClickStep(out, step, flow);
       case 'change':
         return this.#appendChangeStep(out, step, flow);
       case 'setViewport':
@@ -71,15 +73,19 @@ export class CypressStringifyExtension extends StringifyExtension {
 
   #appendClickStep(
     out: LineWriter,
-    step: Schema.ClickStep,
+    step: Schema.ClickStep | Schema.DoubleClickStep,
     flow: Schema.UserFlow
   ): void {
     const cySelector = handleSelectors(step.selectors, flow);
 
     if (cySelector) {
-      out.appendLine(`${cySelector}.click();`);
+      step.type === 'doubleClick'
+        ? out.appendLine(`${cySelector}.dblclick();`)
+        : out.appendLine(`${cySelector}.click();`);
     } else {
-      out.appendLine(' // TODO');
+      console.log(
+        `Warning: The click on ${step.selectors[0]} was not able to be exported to Cypress. Please adjust your selectors and try again.`
+      );
     }
 
     out.appendLine('');

--- a/test/CypressStringifyExtension_test.ts
+++ b/test/CypressStringifyExtension_test.ts
@@ -25,6 +25,23 @@ describe('CypressStringifyExtension', function () {
     assert.equal(writer.toString(), 'cy.get("#test").click();\n');
   });
 
+  it('correctly exports Chrome Recorder doubleClick step', async function () {
+    const ext = new CypressStringifyExtension();
+    const step = {
+      type: 'doubleClick' as const,
+      target: 'main',
+      selectors: [['aria/Test'], ['#test']],
+      offsetX: 1,
+      offsetY: 1,
+    };
+    const flow = { title: 'click step', steps: [step] };
+    const writer = new LineWriterImpl('  ');
+
+    await ext.stringifyStep(writer, step, flow);
+
+    assert.equal(writer.toString(), 'cy.get("#test").dblclick();\n');
+  });
+
   it('correctly exports Chrome Recorder navigate step', async function () {
     const ext = new CypressStringifyExtension();
     const step = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -105,10 +105,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@puppeteer/replay@^0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@puppeteer/replay/-/replay-0.1.1.tgz#a1f7358f786c2795a28d815330bb5ff49717f3e8"
-  integrity sha512-yRLeEdb+QDVpmv3VQlebNdmLxuwGCVuHrUnoMQPuJuXBObKlIIuo2ULzWGW4Gsd4i4vCRdrl4Jxqak8+wHn3lw==
+"@puppeteer/replay@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@puppeteer/replay/-/replay-0.1.2.tgz#40799c9c6f8ad8b2cf5099a8255a8c7d43bb4be2"
+  integrity sha512-tRNzEjj/OvqJQMy66hUYHyzqh5bhMQKl3pSeeLCHM4ZMDW3KXYbacCe8+cDAYZ+aZ5HW0O9tgdyXcsRVl7SsdQ==
 
 "@tsconfig/node10@^1.0.7":
   version "1.0.8"


### PR DESCRIPTION
Converts `doubleClick` type step to `cy.get("_element_").dblclick();`

Partial update for #20.