### PR TITLE
feat: Update the output path from .spec to .cy

### DIFF
--- a/src/cli/transforms.ts
+++ b/src/cli/transforms.ts
@@ -28,7 +28,7 @@ async function exportFileToFolder({
   outputPath,
 }: FileToExport) {
   fs.writeFile(
-    path.join(outputFolder, `/${testName}.spec.js`),
+    path.join(outputFolder, `/${testName}.cy.js`),
     stringifiedFile as string,
     (err: any) => {
       if (!err) {


### PR DESCRIPTION
feat: Update the output path from `.spec` to `.cy` as per Cypress v10

BREAKING CHANGE: Update the output path from .spec to .cy for v10