### PR TITLE
feat(hover): add support for hover

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,15 +79,17 @@ Below are the step types that are currently supported:
 
 | Type                | Description                                   |
 | ------------------- | --------------------------------------------- |
+| change              | becomes **cy.get("_element_").type("text")**  |
 | click               | becomes **cy.get("_element_").click();**      |
 | click (right click) | becomes **cy.get("_element_").rightclick();** |
 | doubleClick         | becomes **cy.get("_element_").dblclick();**   |
-| change              | becomes **cy.get("_element_").type("text")**  |
+| hover               | becomes **cy.get("_element_").trigger();**    |
 | keyDown             | becomes **cy.type("{key}")**                  |
 | keyUp               | _not exported at this time_                   |
 | navigate            | becomes **cy.visit("url")**                   |
 | setViewport         | becomes **cy.viewport(width, height)**        |
 | scroll              | becomes **cy.scrollTo(${step.x}, ${step.y})** |
+
 
 If a step type is not listed above, then a warning message should be displayed in the CLI.
 

--- a/src/CypressStringifyExtension.ts
+++ b/src/CypressStringifyExtension.ts
@@ -50,6 +50,8 @@ export class CypressStringifyExtension extends StringifyExtension {
         return this.#appendNavigationStep(out, step);
       case 'keyDown':
         return this.#appendKeyDownStep(out, step);
+      case 'hover':
+        return this.#appendHoverStep(out, step, flow);
       case 'keyUp':
         return;
       default:
@@ -114,6 +116,20 @@ export class CypressStringifyExtension extends StringifyExtension {
         `Warning: The click on ${step.selectors[0]} was not able to be exported to Cypress. Please adjust your selectors and try again.`
       );
     }
+
+    out.appendLine('');
+  }
+  
+  #appendHoverStep(
+    out: LineWriter,
+    step: Schema.HoverStep,
+    flow: Schema.UserFlow
+  ): void {
+    const cySelector = handleSelectors(step.selectors, flow);
+
+    if (cySelector) {
+      out.appendLine(`${cySelector}.trigger("mouseover");`);
+    } 
 
     out.appendLine('');
   }

--- a/test/CypressStringifyExtension_test.ts
+++ b/test/CypressStringifyExtension_test.ts
@@ -222,4 +222,19 @@ describe('CypressStringifyExtension', function () {
 
     assert.equal(writer.toString(), '');
   });
+
+  it('correctly handles Chrome Recorder hover step', async function () {
+    const ext = new CypressStringifyExtension();
+    const step = {
+      type: 'hover' as const,
+      target: 'main',
+      selectors: [['aria/Test'], ['#test']],
+    };
+    const flow = { title: 'hover step', steps: [step] };
+    const writer = new LineWriterImpl('  ');
+
+    await ext.stringifyStep(writer, step, flow);
+
+    assert.equal(writer.toString(), `cy.get("#test").trigger("mouseenter");\n`);
+  });
 });


### PR DESCRIPTION
A recorder `hover` event will be mapped to `cy.get("#element").trigger("mouseover");`. 

I'm aware of this is not a 1-1 match as trigger event in cypress only works for element with javascript function (e.g. `mouseover`). For element with native `css:hover`, it doesn't trigger the UI changes.

Closes #29.

Refer to: 
- https://docs.cypress.io/api/commands/hover#Add-as-a-custom-command
- https://github.com/cypress-io/cypress/issues/10

Test pages:
- This will work: [hover with JavaScript mouseover event](https://jec.fyi/demo/mouseover)
- This doesn't work: [hover with native css](https://jec.fyi/demo/dbl-right-click)