### PR TITLE
fix(selectors): handle when there are a unique selector

### DIFF
--- a/src/CypressStringifyExtension.ts
+++ b/src/CypressStringifyExtension.ts
@@ -162,10 +162,12 @@ function formatAsJSLiteral(value: string) {
 }
 
 function filterArrayByString(selectors: Schema.Selector[], value: string) {
-  return selectors.filter((selector) =>
-    value === 'aria/'
-      ? !selector[0].includes(value)
-      : selector[0].includes(value)
+  return selectors.filter((selector) => {
+    let userSelector = Array.isArray(selector) ? selector[0] : selector;
+    return value === 'aria/'
+        ? !userSelector.includes(value)
+        : userSelector.includes(value);
+    }
   );
 }
 

--- a/src/CypressStringifyExtension.ts
+++ b/src/CypressStringifyExtension.ts
@@ -187,7 +187,11 @@ function handleSelectors(
   if (preferredSelector && preferredSelector[0]) {
     return `cy.get(${formatAsJSLiteral(preferredSelector[0][0])})`;
   } else {
-    return `cy.get(${formatAsJSLiteral(nonAriaSelectors[0][0])})`;
+    if (Array.isArray(nonAriaSelectors[0])) {
+      return `cy.get(${formatAsJSLiteral(nonAriaSelectors[0][0])})`;
+    }
+
+    return `cy.get(${formatAsJSLiteral(nonAriaSelectors[0])})`;
   }
 }
 

--- a/test/CypressStringifyExtension_test.ts
+++ b/test/CypressStringifyExtension_test.ts
@@ -239,4 +239,18 @@ describe("click step", () => {
     });
     assert.equal(result.toString(), `cy.get("#test").trigger("mouseover");\n`);
   });
+
+  it('correctly handle when there are a unique selector on a any kind of event', async function () {
+    const step = {
+      type: StepType.Click as const,
+      target: 'main',
+      selectors: ['div:nth-of-type(1)'],
+      offsetX: 1,
+      offsetY: 1,
+    };
+    const result = await stringifyStep(step, {
+      extension,
+    });
+    assert.equal(result.toString(), `cy.get("div:nth-of-type(1)").click();\n`);
+  });
 });

--- a/test/CypressStringifyExtension_test.ts
+++ b/test/CypressStringifyExtension_test.ts
@@ -248,13 +248,15 @@ describe("click step", () => {
       offsetX: 1,
       offsetY: 1,
     };
+
     const result = await stringifyStep(step, {
       extension,
     });
+
     assert.equal(result.toString(), `cy.get("div:nth-of-type(1)").click();\n`);
   });
 
-  it('correctly skip aria selectos when there are an array of selectors on any kind of event', async function () {
+  it('correctly skip aria selectors when there are an array of selectors on any kind of event', async function () {
     const step = {
       type: StepType.Click as const,
       target: 'main',
@@ -265,9 +267,11 @@ describe("click step", () => {
       offsetX: 1,
       offsetY: 1,
     };
+
     const result = await stringifyStep(step, {
       extension,
     });
+
     assert.equal(result.toString(), `cy.get("main button").click();\n`);
   });
 });

--- a/test/CypressStringifyExtension_test.ts
+++ b/test/CypressStringifyExtension_test.ts
@@ -253,4 +253,21 @@ describe("click step", () => {
     });
     assert.equal(result.toString(), `cy.get("div:nth-of-type(1)").click();\n`);
   });
+
+  it('correctly skip aria selectos when there are an array of selectors on any kind of event', async function () {
+    const step = {
+      type: StepType.Click as const,
+      target: 'main',
+      selectors: [
+        "aria/npm install cypress",
+        "main button",
+      ],
+      offsetX: 1,
+      offsetY: 1,
+    };
+    const result = await stringifyStep(step, {
+      extension,
+    });
+    assert.equal(result.toString(), `cy.get("main button").click();\n`);
+  });
 });


### PR DESCRIPTION
Hello :)

Some time we can edit chrome generated selectors, that's means, the result of the selectors in the json file is a `Array<string> `instead of `Array<Array<string>>`

[More about selector types in replay repo](https://github.com/puppeteer/replay/blob/main/docs/api/modules/Schema.md#selector)


Example in a video:
https://github.com/cypress-io/cypress-chrome-recorder/assets/8685132/6721e734-6a79-4708-8664-022e576c3de0

